### PR TITLE
Fixed Invalid XML with ID attribute on Link tag

### DIFF
--- a/HPS/Heartland/view/adminhtml/layout/sales_order_create_index.xml
+++ b/HPS/Heartland/view/adminhtml/layout/sales_order_create_index.xml
@@ -11,7 +11,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <script src="https://hps.github.io/token/2.1/securesubmit.js" src_type="url" />
-        <link src="HPS_Heartland/js/view/payment/securesubmit.js" id="HPS_SECURESUBMIT_IFRAME_CODE"/>
+        <link src="HPS_Heartland/js/view/payment/securesubmit.js" />
         <css  src="HPS_Heartland/creditForm.css" />
     </head>
     <body>    

--- a/HPS/Heartland/view/adminhtml/web/js/view/payment/securesubmit.js
+++ b/HPS/Heartland/view/adminhtml/web/js/view/payment/securesubmit.js
@@ -12,7 +12,9 @@
 
 var getImageURL = (function () {
     //build a relative path based on the module location on the configured server
-    var myScript = document.querySelector('script#HPS_SECURESUBMIT_IFRAME_CODE').src.split('/').slice(0,-4).join('/') + '/images/';
+    var scripts = document.getElementsByTagName('script');
+    var element = scripts[scripts.length-1];
+    var myScript = element.src.split('/').slice(0,-4).join('/') + '/images/';
     //console.log(myScript);
     return function () {
         return myScript;

--- a/HPS/Heartland/view/frontend/layout/checkout_index_index.xml
+++ b/HPS/Heartland/view/frontend/layout/checkout_index_index.xml
@@ -18,7 +18,7 @@
         <!-- PROD
         <script src="https://api2.heartlandportico.com/SecureSubmit.v1/token/2.1/securesubmit.js" src_type="url" />
         -->
-        <link src="HPS_Heartland/js/view/payment/securesubmit.js" id="HPS_SECURESUBMIT_IFRAME_CODE"/>
+        <link src="HPS_Heartland/js/view/payment/securesubmit.js" />
         <css  src="HPS_Heartland/creditForm.css" />
 
     </head>

--- a/HPS/Heartland/view/frontend/layout/vault_cards_listaction.xml
+++ b/HPS/Heartland/view/frontend/layout/vault_cards_listaction.xml
@@ -19,7 +19,7 @@
         <!-- PROD
         <script src="https://api2.heartlandportico.com/SecureSubmit.v1/token/2.1/securesubmit.js" src_type="url" />
         -->
-        <link src="HPS_Heartland/js/view/payment/securesubmit.js" id="HPS_SECURESUBMIT_IFRAME_CODE"/>
+        <link src="HPS_Heartland/js/view/payment/securesubmit.js" />
         <css  src="HPS_Heartland/creditForm.css" />
     </head>
     <body>

--- a/HPS/Heartland/view/frontend/web/js/view/payment/securesubmit.js
+++ b/HPS/Heartland/view/frontend/web/js/view/payment/securesubmit.js
@@ -2,7 +2,8 @@
 
 var getImageURL = (function () {
     //build a relative path based on the module location on the configured server
-    var element = document.querySelector('script#HPS_SECURESUBMIT_IFRAME_CODE');
+    var scripts = document.getElementsByTagName('script');
+    var element = scripts[scripts.length-1];
     if (element !== null) {
         var myScript = element.src.split('/').slice(0, -4).join('/') + '/images/';
         //console.log(myScript);


### PR DESCRIPTION
I am currently running Magento 2.2.4 and installing this module fails on the checkout page due to invalid XML. It appears that there are a few places where an ID attribute is added to a `<link>` element and it is failing the schema validation in the current version of Magento. ID is not a valid attribute for the link attribute technically. For reference of valid attributes on the `<link>` tag inside M2 XML see the documentation here - https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-types.html. 

I removed the ID attribute and updated the JS accordingly. The solution isn't the best to be honest, but I couldn't think of a better way at the moment without refactoring the module to use config providers for passing valid URL builder results from PHP to JS. 

The solution suggested here just grabs the last `<script>` tag to be added. The currently executing file will always be the last in the array, assuming the JS is executed at load. So at the time of executing the code in `getImageURL` the `securesubmit.js` file is the last one in the array of scripts. 