### PR TITLE
Moved Payment preference to global so it works with API

### DIFF
--- a/HPS/Heartland/etc/adminhtml/di.xml
+++ b/HPS/Heartland/etc/adminhtml/di.xml
@@ -25,7 +25,6 @@
             </argument>
         </arguments>
     </type>
-    <preference for="Magento\Sales\Model\Order\Payment" type="\HPS\Heartland\Model\Order\Payment" />
     <preference for="\Magento\Payment\Block\Form\Cc" type="\HPS\Heartland\Block\Form\Cc" />
 
 </config>

--- a/HPS/Heartland/etc/di.xml
+++ b/HPS/Heartland/etc/di.xml
@@ -24,6 +24,7 @@
                 <item name="hps_heartland_config_provider" xsi:type="object">HPS\Heartland\Model\ConfigProvider</item>
             </argument>
         </arguments>
-    </type>    
+    </type>
+    <preference for="Magento\Sales\Model\Order\Payment" type="\HPS\Heartland\Model\Order\Payment" />
 
 </config>


### PR DESCRIPTION
This fixes issue #36 .

When invoicing an order through the Magento API the Heartland `Payment` class is not used as the `<preference>` is set in the `adminhtml` scope instead of globally. This PR simply moves that preference declaration to the global `di.xml`. 