### PR TITLE
Fixing issue thrown in Magento 2.3.4

### DIFF
--- a/HPS/Heartland/Controller/Creditcard/CanSave.php
+++ b/HPS/Heartland/Controller/Creditcard/CanSave.php
@@ -55,6 +55,6 @@ class CanSave extends \Magento\Framework\App\Action\Action
         $resultRaw = $this->resultRawFactory->create();
 
         // # \HPS\Heartland\Model\StoredCard::getCanStoreCards
-        return $resultRaw->setContents((int) $this->hpsStoredCard->getCanStoreCards());
+        return $resultRaw->setContents((string) $this->hpsStoredCard->getCanStoreCards());
     }
 }


### PR DESCRIPTION
Error reported to shane.logsdon@heartland.us and submitting PR as per discussion.
Error details: strpos() expects parameter 1 to be string in vendor/..../module_theme/.../JsFooterPlugin.php:44